### PR TITLE
took client execution off the UI thread.

### DIFF
--- a/src/android/CPGoogleAnalyticsAdId.java
+++ b/src/android/CPGoogleAnalyticsAdId.java
@@ -82,7 +82,7 @@ public class CPGoogleAnalyticsAdId extends CordovaPlugin {
   }
 
   private PluginResult execGetAdId(final CallbackContext callbackContext) {
-    cordova.getActivity().runOnUiThread(new Runnable() {
+    cordova.getThreadPool().execute(new Runnable() {
       @Override
       public void run() {
         AdvertisingIdClient.Info advId;


### PR DESCRIPTION
The UI thread is for UI tasks, and this generates an error indicating
that it should not be run on the UI thread.
